### PR TITLE
bug/ch36319/koolreport-assets-are-not-loading-properly

### DIFF
--- a/scripts/site-types/apache.sh
+++ b/scripts/site-types/apache.sh
@@ -123,7 +123,7 @@ blockssl="<IfModule mod_ssl.c>
         <IfModule !mod_fastcgi.c>
             <IfModule mod_proxy_fcgi.c>
                 <FilesMatch \".+\.ph(ar|p|tml)$\">
-                    SetHandler \"proxy:unix:/var/run/php/php"$5"-fpm.sock|fcgi://localhost/\"
+                    SetHandler \"proxy:unix:/var/run/php/php"$5"-fpm.sock|fcgi://localhost\"
                 </FilesMatch>
             </IfModule>
         </IfModule>


### PR DESCRIPTION
## Cause
KoolReport uses ```$_SERVER["SCRIPT_FILENAME"]``` variable to generate KoolReport assets URL. This variable contained leading double slash ```//``` because of a minor misconfiguration on apache2 config file. I suspect this bug's effects are not limited to KoolReport only. 

## Fix
Misconfiguration on apache2 config file is corrected. After this fix, the bug should not exist while setting up a new Homestead devbox. For existing Homestead devbox, you can either run vagrant up/reload with --provision flag, or ssh into devbox and perform the following

- ```sudo nano /etc/apache2/sites-enabled/local.campgroundreviews.com-ssl.conf```
-  Find the following config block
```bash
        <IfModule !mod_fastcgi.c>
            <IfModule mod_proxy_fcgi.c>
                <FilesMatch ".+\.ph(ar|p|tml)$">
                    SetHandler "proxy:unix:/var/run/php/php7.3-fpm.sock|fcgi://localhost/"
                </FilesMatch>
            </IfModule>
        </IfModule>
```
- Remove the trailing slash on ```localhost```
```bash
SetHandler "proxy:unix:/var/run/php/php7.3-fpm.sock|fcgi://localhost"
```
- Repeat the above steps for other config files *-ssl.conf on ```/etc/apache2/sites-enabled/``` directory 

https://app.clubhouse.io/socialknowledge/story/36319/koolreport-assets-are-not-loading-properly-on-new-homestead-devbox